### PR TITLE
Fix header to be above map zoom ctrl

### DIFF
--- a/css/livecod-lsy.css
+++ b/css/livecod-lsy.css
@@ -87,7 +87,7 @@ header{
   height: 60px;
   padding: 15px;
   background: #fff;
-  z-index: 100;
+  z-index: 800;
 }
 header h1 img{
   vertical-align: top;


### PR DESCRIPTION
Naver Maps zoom control의 z-index보다 header가 높아야만 스크롤 시 가려지지 않기 때문에 수정했습니다.
Bootstrap 4의 z-index도 참고해 modal/dropdown 등과 같은 element보다는 낮아야 하기 때문에 800으로 했으며 추후 수정이 가능합니다.

Closes #23 